### PR TITLE
Slot Linear Effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 dist
 .dist
 /.vs
-/shared/src/level/bgm.mp3

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .dev
 dist
 .dist
+/.vs
+/shared/src/level/bgm.mp3

--- a/play/src/engine/playData/archetypes/notes/flatNotes/FlatNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/FlatNote.js
@@ -90,6 +90,9 @@ export class FlatNote extends Note {
             ? this.effects.linearFallback.id
             : this.effects.linear.id;
     }
+    get slotEffectId() {
+        return this.effects.slotEffects.id
+    }
     scheduleSFX() {
         if ('fallback' in this.clips && this.useFallbackClip) {
             this.clips.fallback.schedule(this.targetTime, sfxDistance);
@@ -116,6 +119,8 @@ export class FlatNote extends Note {
             this.playNoteEffects();
         if (options.slotEffectEnabled)
             this.playSlotEffects(hitTime);
+        if (options.slotLinearEnabled)
+            this.playSlotLinears();
         if (options.laneEffectEnabled)
             this.playLaneEffects();
     }
@@ -156,6 +161,23 @@ export class FlatNote extends Note {
             w: 1.75,
             h: 1.05,
         }), 0.6, false);
+    }
+    playSlotLinears() {
+        if (this.effects.slotEffects.exists && options.slotLinearEnabled) {
+            const start = Math.floor(this.import.lane - this.import.size)
+            const end = Math.ceil(this.import.lane + this.import.size)
+            for (let i = start; i < end; i++) {
+                particle.effects.spawn(
+                    this.slotEffectId,
+                    linearEffectLayout({
+                        lane: i + 0.5,
+                        shear: 0,
+                    }),
+                    0.5,
+                    false,
+                )
+            }
+        }
     }
     playSlotEffects(startTime) {
         const start = Math.floor(this.import.lane - this.import.size);

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.js
@@ -1,13 +1,14 @@
-import { lane } from '../../../../../../../../shared/src/engine/data/lane.js';
-import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../buckets.js';
-import { effect } from '../../../../effect.js';
-import { particle } from '../../../../particle.js';
-import { skin } from '../../../../skin.js';
-import { archetypes } from '../../../index.js';
-import { FlickNote } from './FlickNote.js';
-
-export class CriticalFlickNote extends FlickNote {
+import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.js';
+import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../../buckets.js';
+import { effect } from '../../../../../effect.js';
+import { lane } from '../../../../../lane.js';
+import { particle } from '../../../../../particle.js';
+import { skin } from '../../../../../skin.js';
+import { archetypes } from '../../../../index.js';
+import { SingleFlickNote } from './SingleFlickNote.js';
+import { SharedLaneEffectUtils } from '../SharedLaneEffectUtils.js';
+export class CriticalFlickNote extends SingleFlickNote {
     sprites = {
         left: skin.sprites.criticalNoteLeft,
         middle: skin.sprites.criticalNoteMiddle,
@@ -53,17 +54,23 @@ export class CriticalFlickNote extends FlickNote {
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect;
     }
+
     playLaneEffects() {
+        if (particle.effects.criticalFlickLane.exists) {
+            this.check = true;
+        }
+        else {
+            particle.effects.lane.spawn(perspectiveLayout({
+                l: this.import.lane - this.import.size,
+                r: this.import.lane + this.import.size,
+                b: lane.b,
+                t: lane.t,
+            }), 0.3, false);
+        }
     }
-    preprocess() {
-        super.preprocess();
-        const l = this.import.lane - this.import.size;
-        const r = this.import.lane + this.import.size;
-        const t = this.hitTime
-        const laneB = lane.b
-        const laneT = lane.t
-        archetypes.LaneEffectSpawner.spawn({
-            l: l, r: r, t: t, laneB: laneB, laneT: laneT, j: this.import.judgment,
-        });
+    touch() {
+        super.touch();
+        if (!this.check) return
+        SharedLaneEffectUtils.playAndHandleLaneEffect(this, this.laneE);
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/CriticalFlickNote.js
@@ -1,14 +1,13 @@
-import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.js';
-import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../../buckets.js';
-import { effect } from '../../../../../effect.js';
-import { lane } from '../../../../../lane.js';
-import { particle } from '../../../../../particle.js';
-import { skin } from '../../../../../skin.js';
-import { archetypes } from '../../../../index.js';
-import { SingleFlickNote } from './SingleFlickNote.js';
-import { SharedLaneEffectUtils } from '../SharedLaneEffectUtils.js';
-export class CriticalFlickNote extends SingleFlickNote {
+import { lane } from '../../../../../../../../shared/src/engine/data/lane.js';
+import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../buckets.js';
+import { effect } from '../../../../effect.js';
+import { particle } from '../../../../particle.js';
+import { skin } from '../../../../skin.js';
+import { archetypes } from '../../../index.js';
+import { FlickNote } from './FlickNote.js';
+
+export class CriticalFlickNote extends FlickNote {
     sprites = {
         left: skin.sprites.criticalNoteLeft,
         middle: skin.sprites.criticalNoteMiddle,
@@ -24,6 +23,7 @@ export class CriticalFlickNote extends SingleFlickNote {
         circularFallback: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalFlickNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectFlickYellow,
     };
     arrowSprites = {
         up: [
@@ -53,23 +53,17 @@ export class CriticalFlickNote extends SingleFlickNote {
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect;
     }
-
     playLaneEffects() {
-        if (particle.effects.criticalFlickLane.exists) {
-            this.check = true;
-        }
-        else {
-            particle.effects.lane.spawn(perspectiveLayout({
-                l: this.import.lane - this.import.size,
-                r: this.import.lane + this.import.size,
-                b: lane.b,
-                t: lane.t,
-            }), 0.3, false);
-        }
     }
-    touch() {
-        super.touch();
-        if (!this.check) return
-        SharedLaneEffectUtils.playAndHandleLaneEffect(this, this.laneE);
+    preprocess() {
+        super.preprocess();
+        const l = this.import.lane - this.import.size;
+        const r = this.import.lane + this.import.size;
+        const t = this.hitTime
+        const laneB = lane.b
+        const laneT = lane.t
+        archetypes.LaneEffectSpawner.spawn({
+            l: l, r: r, t: t, laneB: laneB, laneT: laneT, j: this.import.judgment,
+        });
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/NormalFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/NormalFlickNote.js
@@ -1,11 +1,11 @@
-import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../../buckets.js';
-import { effect } from '../../../../../effect.js';
-import { particle } from '../../../../../particle.js';
-import { skin } from '../../../../../skin.js';
-import { archetypes } from '../../../../index.js';
-import { SingleFlickNote } from './SingleFlickNote.js';
-export class NormalFlickNote extends SingleFlickNote {
+import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../buckets.js';
+import { effect } from '../../../../effect.js';
+import { particle } from '../../../../particle.js';
+import { skin } from '../../../../skin.js';
+import { archetypes } from '../../../index.js';
+import { FlickNote } from './FlickNote.js';
+export class NormalFlickNote extends FlickNote {
     sprites = {
         left: skin.sprites.flickNoteLeft,
         middle: skin.sprites.flickNoteMiddle,
@@ -20,6 +20,7 @@ export class NormalFlickNote extends SingleFlickNote {
     effects = {
         circular: particle.effects.flickNoteCircular,
         linear: particle.effects.flickNoteLinear,
+        slotEffects: particle.effects.slotEffectFlickRed,
     };
     arrowSprites = {
         up: [

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/NormalFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/singleFlickNotes/NormalFlickNote.js
@@ -1,11 +1,11 @@
-import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../buckets.js';
-import { effect } from '../../../../effect.js';
-import { particle } from '../../../../particle.js';
-import { skin } from '../../../../skin.js';
-import { archetypes } from '../../../index.js';
-import { FlickNote } from './FlickNote.js';
-export class NormalFlickNote extends FlickNote {
+import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../../buckets.js';
+import { effect } from '../../../../../effect.js';
+import { particle } from '../../../../../particle.js';
+import { skin } from '../../../../../skin.js';
+import { archetypes } from '../../../../index.js';
+import { SingleFlickNote } from './SingleFlickNote.js';
+export class NormalFlickNote extends SingleFlickNote {
     sprites = {
         left: skin.sprites.flickNoteLeft,
         middle: skin.sprites.flickNoteMiddle,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.js
@@ -1,14 +1,16 @@
-import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.js';
-import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../../buckets.js';
-import { effect } from '../../../../../effect.js';
-import { lane } from '../../../../../lane.js';
-import { particle } from '../../../../../particle.js';
-import { skin } from '../../../../../skin.js';
-import { archetypes } from '../../../../index.js';
-import { SlideEndFlickNote } from './SlideEndFlickNote.js';
-import { SharedLaneEffectUtils } from '../SharedLaneEffectUtils.js';
-export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
+import { lane } from '../../../../../../../../shared/src/engine/data/lane.js';
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.js';
+import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../buckets.js';
+import { effect } from '../../../../effect.js';
+import { particle } from '../../../../particle.js';
+import { skin } from '../../../../skin.js';
+import { archetypes } from '../../../index.js';
+import { FlickNote } from './FlickNote.js';
+import { SharedLaneEffectUtils } from './SharedLaneEffectUtils.js';
+import { options } from '../../../../../configuration/options.js'
+
+export class CriticalSlideEndFlickNote extends FlickNote {
     sprites = {
         left: skin.sprites.criticalNoteLeft,
         middle: skin.sprites.criticalNoteMiddle,
@@ -24,6 +26,7 @@ export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
         circularFallback: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalFlickNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectFlickYellow,
     };
     arrowSprites = {
         up: [
@@ -54,21 +57,16 @@ export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
         return archetypes.CriticalSlotGlowEffect;
     }
     playLaneEffects() {
-        if (particle.effects.criticalFlickLane.exists) {
-            this.check = true;
-        }
-        else {
-            particle.effects.lane.spawn(perspectiveLayout({
-                l: this.import.lane - this.import.size,
-                r: this.import.lane + this.import.size,
-                b: lane.b,
-                t: lane.t,
-            }), 0.3, false);
-        }
     }
-    touch() {
-        super.touch();
-        if (!this.check) return
-        SharedLaneEffectUtils.playAndHandleLaneEffect(this, this.laneE);
+    preprocess() {
+        super.preprocess();
+        const l = this.import.lane - this.import.size;
+        const r = this.import.lane + this.import.size;
+        const t = this.hitTime
+        const laneB = lane.b
+        const laneT = lane.t
+        archetypes.LaneEffectSpawner.spawn({
+            l: l, r: r, t: t, laneB: laneB, laneT: laneT, j: this.import.judgment,
+        });
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/CriticalSlideEndFlickNote.js
@@ -1,16 +1,14 @@
-import { lane } from '../../../../../../../../shared/src/engine/data/lane.js';
-import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.js';
-import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../buckets.js';
-import { effect } from '../../../../effect.js';
-import { particle } from '../../../../particle.js';
-import { skin } from '../../../../skin.js';
-import { archetypes } from '../../../index.js';
-import { FlickNote } from './FlickNote.js';
-import { SharedLaneEffectUtils } from './SharedLaneEffectUtils.js';
-import { options } from '../../../../../configuration/options.js'
-
-export class CriticalSlideEndFlickNote extends FlickNote {
+import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.js';
+import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../../buckets.js';
+import { effect } from '../../../../../effect.js';
+import { lane } from '../../../../../lane.js';
+import { particle } from '../../../../../particle.js';
+import { skin } from '../../../../../skin.js';
+import { archetypes } from '../../../../index.js';
+import { SlideEndFlickNote } from './SlideEndFlickNote.js';
+import { SharedLaneEffectUtils } from '../SharedLaneEffectUtils.js';
+export class CriticalSlideEndFlickNote extends SlideEndFlickNote {
     sprites = {
         left: skin.sprites.criticalNoteLeft,
         middle: skin.sprites.criticalNoteMiddle,
@@ -57,16 +55,21 @@ export class CriticalSlideEndFlickNote extends FlickNote {
         return archetypes.CriticalSlotGlowEffect;
     }
     playLaneEffects() {
+        if (particle.effects.criticalFlickLane.exists) {
+            this.check = true;
+        }
+        else {
+            particle.effects.lane.spawn(perspectiveLayout({
+                l: this.import.lane - this.import.size,
+                r: this.import.lane + this.import.size,
+                b: lane.b,
+                t: lane.t,
+            }), 0.3, false);
+        }
     }
-    preprocess() {
-        super.preprocess();
-        const l = this.import.lane - this.import.size;
-        const r = this.import.lane + this.import.size;
-        const t = this.hitTime
-        const laneB = lane.b
-        const laneT = lane.t
-        archetypes.LaneEffectSpawner.spawn({
-            l: l, r: r, t: t, laneB: laneB, laneT: laneT, j: this.import.judgment,
-        });
+    touch() {
+        super.touch();
+        if (!this.check) return
+        SharedLaneEffectUtils.playAndHandleLaneEffect(this, this.laneE);
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/NormalSlideEndFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/NormalSlideEndFlickNote.js
@@ -1,11 +1,11 @@
-import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../buckets.js';
-import { effect } from '../../../../effect.js';
-import { particle } from '../../../../particle.js';
-import { skin } from '../../../../skin.js';
-import { archetypes } from '../../../index.js';
-import { FlickNote } from './FlickNote.js';
-export class NormalSlideEndFlickNote extends FlickNote {
+import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../../buckets.js';
+import { effect } from '../../../../../effect.js';
+import { particle } from '../../../../../particle.js';
+import { skin } from '../../../../../skin.js';
+import { archetypes } from '../../../../index.js';
+import { SlideEndFlickNote } from './SlideEndFlickNote.js';
+export class NormalSlideEndFlickNote extends SlideEndFlickNote {
     sprites = {
         left: skin.sprites.flickNoteLeft,
         middle: skin.sprites.flickNoteMiddle,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/NormalSlideEndFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/slideEndFlickNotes/NormalSlideEndFlickNote.js
@@ -1,11 +1,11 @@
-import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../../buckets.js';
-import { effect } from '../../../../../effect.js';
-import { particle } from '../../../../../particle.js';
-import { skin } from '../../../../../skin.js';
-import { archetypes } from '../../../../index.js';
-import { SlideEndFlickNote } from './SlideEndFlickNote.js';
-export class NormalSlideEndFlickNote extends SlideEndFlickNote {
+import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../buckets.js';
+import { effect } from '../../../../effect.js';
+import { particle } from '../../../../particle.js';
+import { skin } from '../../../../skin.js';
+import { archetypes } from '../../../index.js';
+import { FlickNote } from './FlickNote.js';
+export class NormalSlideEndFlickNote extends FlickNote {
     sprites = {
         left: skin.sprites.flickNoteLeft,
         middle: skin.sprites.flickNoteMiddle,
@@ -20,6 +20,7 @@ export class NormalSlideEndFlickNote extends SlideEndFlickNote {
     effects = {
         circular: particle.effects.flickNoteCircular,
         linear: particle.effects.flickNoteLinear,
+        slotEffects: particle.effects.slotEffectFlickRed,
     };
     arrowSprites = {
         up: [

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.js
@@ -1,13 +1,14 @@
+import { lane } from '../../../../../../../../../shared/src/engine/data/lane.js';
 import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.js';
 import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
 import { buckets } from '../../../../../buckets.js';
 import { effect } from '../../../../../effect.js';
-import { lane } from '../../../../../lane.js';
 import { particle } from '../../../../../particle.js';
 import { skin } from '../../../../../skin.js';
 import { archetypes } from '../../../../index.js';
 import { TraceFlickNote } from './TraceFlickNote.js';
-import { SharedLaneEffectUtils } from '../SharedLaneEffectUtils.js';
+import { options } from '../../../../../../configuration/options.js'
+
 export class CriticalTraceFlickNote extends TraceFlickNote {
     sprites = {
         left: skin.sprites.criticalTraceNoteLeft,
@@ -23,6 +24,7 @@ export class CriticalTraceFlickNote extends TraceFlickNote {
     effects = {
         circular: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     arrowSprites = {
         up: [
@@ -49,18 +51,17 @@ export class CriticalTraceFlickNote extends TraceFlickNote {
     get slotEffect() {
         return archetypes.CriticalSlotEffect;
     }
-    get slotGlowEffect() {
-        return archetypes.CriticalSlotGlowEffect;
-    }
-
     playLaneEffects() {
-        if (particle.effects.criticalFlickLane.exists) {
-            this.check = true;
-        }
     }
-    touch() {
-        super.touch();
-        if (!this.check) return
-        SharedLaneEffectUtils.playAndHandleLaneEffect(this, this.laneE);
+    preprocess() {
+        super.preprocess();
+        const l = this.import.lane - this.import.size;
+        const r = this.import.lane + this.import.size;
+        const t = this.hitTime
+        const laneB = lane.b
+        const laneT = lane.t
+        archetypes.LaneEffectSpawner.spawn({
+            l: l, r: r, t: t, laneB: laneB, laneT: laneT, j: this.import.judgment,
+        });
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.js
@@ -1,14 +1,13 @@
-import { lane } from '../../../../../../../../../shared/src/engine/data/lane.js';
 import { perspectiveLayout } from '../../../../../../../../../shared/src/engine/data/utils.js';
 import { windows } from '../../../../../../../../../shared/src/engine/data/windows.js';
 import { buckets } from '../../../../../buckets.js';
 import { effect } from '../../../../../effect.js';
+import { lane } from '../../../../../lane.js';
 import { particle } from '../../../../../particle.js';
 import { skin } from '../../../../../skin.js';
 import { archetypes } from '../../../../index.js';
 import { TraceFlickNote } from './TraceFlickNote.js';
-import { options } from '../../../../../../configuration/options.js'
-
+import { SharedLaneEffectUtils } from '../SharedLaneEffectUtils.js';
 export class CriticalTraceFlickNote extends TraceFlickNote {
     sprites = {
         left: skin.sprites.criticalTraceNoteLeft,
@@ -51,17 +50,18 @@ export class CriticalTraceFlickNote extends TraceFlickNote {
     get slotEffect() {
         return archetypes.CriticalSlotEffect;
     }
-    playLaneEffects() {
+    get slotGlowEffect() {
+        return archetypes.CriticalSlotGlowEffect;
     }
-    preprocess() {
-        super.preprocess();
-        const l = this.import.lane - this.import.size;
-        const r = this.import.lane + this.import.size;
-        const t = this.hitTime
-        const laneB = lane.b
-        const laneT = lane.t
-        archetypes.LaneEffectSpawner.spawn({
-            l: l, r: r, t: t, laneB: laneB, laneT: laneT, j: this.import.judgment,
-        });
+
+    playLaneEffects() {
+        if (particle.effects.criticalFlickLane.exists) {
+            this.check = true;
+        }
+    }
+    touch() {
+        super.touch();
+        if (!this.check) return
+        SharedLaneEffectUtils.playAndHandleLaneEffect(this, this.laneE);
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/NormalTraceFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/NormalTraceFlickNote.js
@@ -21,6 +21,7 @@ export class NormalTraceFlickNote extends TraceFlickNote {
     effects = {
         circular: particle.effects.flickNoteCircular,
         linear: particle.effects.flickNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     arrowSprites = {
         up: [

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/TraceFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/TraceFlickNote.js
@@ -1,18 +1,19 @@
+import { minFlickVR } from '../../../../../flick.js';
 import { note } from '../../../../../note.js';
 import { scaledScreen } from '../../../../../scaledScreen.js';
 import { getZ, layer } from '../../../../../skin.js';
+import { disallowEmpty } from '../../../../InputManager.js';
 import { FlickNote } from '../FlickNote.js';
 export class TraceFlickNote extends FlickNote {
+    earlyInputTime = this.entityMemory(Number);
+    earlyHitTime = this.entityMemory(Number);
+    earlyHitIsCorrectDirection = this.entityMemory(Boolean);
     diamondLayout = this.entityMemory(Rect);
     diamondZ = this.entityMemory(Number);
-    get useFallbackSprites() {
-        return (!this.sprites.left.exists ||
-            !this.sprites.middle.exists ||
-            !this.sprites.right.exists ||
-            !this.sprites.diamond.exists);
-    }
-    globalInitialize() {
-        super.globalInitialize();
+    initialize() {
+        super.initialize();
+        this.earlyInputTime = this.targetTime + input.offset;
+        this.earlyHitTime = -9999;
         if (!this.useFallbackSprites) {
             const w = note.h / scaledScreen.wToH;
             new Rect({
@@ -24,6 +25,53 @@ export class TraceFlickNote extends FlickNote {
             this.diamondZ = getZ(layer.note.tick, this.targetTime, this.import.lane);
         }
     }
+    touch() {
+        if (time.now < this.inputTime.min)
+            return;
+        if (time.now < this.earlyInputTime) {
+            this.earlyTouch();
+        }
+        else {
+            this.lateTouch();
+        }
+    }
+    updateParallel() {
+        this.triggerEarlyTouch();
+        super.updateParallel();
+    }
+    earlyTouch() {
+        for (const touch of touches) {
+            if (touch.vr < minFlickVR)
+                continue;
+            if (!this.fullHitbox.contains(touch.position))
+                continue;
+            disallowEmpty(touch);
+            this.earlyHitTime = touch.time;
+            this.earlyHitIsCorrectDirection = this.isCorrectDirection(touch);
+            return;
+        }
+    }
+    lateTouch() {
+        for (const touch of touches) {
+            if (touch.vr < minFlickVR)
+                continue;
+            if (!this.fullHitbox.contains(touch.lastPosition))
+                continue;
+            disallowEmpty(touch);
+            this.completeTraceFlick(Math.max(touch.time, this.targetTime), this.isCorrectDirection(touch));
+            return;
+        }
+    }
+    triggerEarlyTouch() {
+        if (this.despawn)
+            return;
+        if (time.now < this.earlyInputTime)
+            return;
+        if (this.earlyHitTime === -9999)
+            return;
+        this.completeTraceFlick(this.earlyHitTime, this.earlyHitIsCorrectDirection);
+        this.despawn = true;
+    }
     render() {
         super.render();
         if (!this.useFallbackSprites) {
@@ -33,13 +81,35 @@ export class TraceFlickNote extends FlickNote {
     playNoteEffects() {
         this.playDirectionalNoteEffect();
     }
-    playLaneEffects() {
+    playSlotEffects() {
         // removed
     }
     playSlotLinears() {
+        //removed
+    }
+    playLaneEffects() {
         // removed
     }
-    spawnSlotEffects() {
-        // removed
+    completeTraceFlick(hitTime, isCorrectDirection) {
+        this.result.judgment = input.judge(hitTime, this.targetTime, this.windows);
+        this.result.accuracy = hitTime - this.targetTime;
+        if (!isCorrectDirection) {
+            if (this.result.judgment === Judgment.Perfect)
+                this.result.judgment = Judgment.Great;
+            if (this.result.accuracy < this.windows.perfect.max) {
+                this.flickExport('accuracyDiff', this.result.accuracy - this.windows.perfect.max);
+                this.result.accuracy = this.windows.perfect.max;
+            }
+        }
+        this.result.bucket.index = this.bucket.index;
+        this.result.bucket.value = this.result.accuracy * 1000;
+        this.playHitEffects(time.now);
+        this.despawn = true;
+    }
+    get useFallbackSprites() {
+        return (!this.sprites.left.exists ||
+            !this.sprites.middle.exists ||
+            !this.sprites.right.exists ||
+            !this.sprites.diamond.exists);
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/TraceFlickNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/TraceFlickNote.js
@@ -1,19 +1,18 @@
-import { minFlickVR } from '../../../../../flick.js';
 import { note } from '../../../../../note.js';
 import { scaledScreen } from '../../../../../scaledScreen.js';
 import { getZ, layer } from '../../../../../skin.js';
-import { disallowEmpty } from '../../../../InputManager.js';
 import { FlickNote } from '../FlickNote.js';
 export class TraceFlickNote extends FlickNote {
-    earlyInputTime = this.entityMemory(Number);
-    earlyHitTime = this.entityMemory(Number);
-    earlyHitIsCorrectDirection = this.entityMemory(Boolean);
     diamondLayout = this.entityMemory(Rect);
     diamondZ = this.entityMemory(Number);
-    initialize() {
-        super.initialize();
-        this.earlyInputTime = this.targetTime + input.offset;
-        this.earlyHitTime = -9999;
+    get useFallbackSprites() {
+        return (!this.sprites.left.exists ||
+            !this.sprites.middle.exists ||
+            !this.sprites.right.exists ||
+            !this.sprites.diamond.exists);
+    }
+    globalInitialize() {
+        super.globalInitialize();
         if (!this.useFallbackSprites) {
             const w = note.h / scaledScreen.wToH;
             new Rect({
@@ -25,53 +24,6 @@ export class TraceFlickNote extends FlickNote {
             this.diamondZ = getZ(layer.note.tick, this.targetTime, this.import.lane);
         }
     }
-    touch() {
-        if (time.now < this.inputTime.min)
-            return;
-        if (time.now < this.earlyInputTime) {
-            this.earlyTouch();
-        }
-        else {
-            this.lateTouch();
-        }
-    }
-    updateParallel() {
-        this.triggerEarlyTouch();
-        super.updateParallel();
-    }
-    earlyTouch() {
-        for (const touch of touches) {
-            if (touch.vr < minFlickVR)
-                continue;
-            if (!this.fullHitbox.contains(touch.position))
-                continue;
-            disallowEmpty(touch);
-            this.earlyHitTime = touch.time;
-            this.earlyHitIsCorrectDirection = this.isCorrectDirection(touch);
-            return;
-        }
-    }
-    lateTouch() {
-        for (const touch of touches) {
-            if (touch.vr < minFlickVR)
-                continue;
-            if (!this.fullHitbox.contains(touch.lastPosition))
-                continue;
-            disallowEmpty(touch);
-            this.completeTraceFlick(Math.max(touch.time, this.targetTime), this.isCorrectDirection(touch));
-            return;
-        }
-    }
-    triggerEarlyTouch() {
-        if (this.despawn)
-            return;
-        if (time.now < this.earlyInputTime)
-            return;
-        if (this.earlyHitTime === -9999)
-            return;
-        this.completeTraceFlick(this.earlyHitTime, this.earlyHitIsCorrectDirection);
-        this.despawn = true;
-    }
     render() {
         super.render();
         if (!this.useFallbackSprites) {
@@ -81,32 +33,13 @@ export class TraceFlickNote extends FlickNote {
     playNoteEffects() {
         this.playDirectionalNoteEffect();
     }
-    playSlotEffects() {
-        // removed
-    }
     playLaneEffects() {
         // removed
     }
-    completeTraceFlick(hitTime, isCorrectDirection) {
-        this.result.judgment = input.judge(hitTime, this.targetTime, this.windows);
-        this.result.accuracy = hitTime - this.targetTime;
-        if (!isCorrectDirection) {
-            if (this.result.judgment === Judgment.Perfect)
-                this.result.judgment = Judgment.Great;
-            if (this.result.accuracy < this.windows.perfect.max) {
-                this.flickExport('accuracyDiff', this.result.accuracy - this.windows.perfect.max);
-                this.result.accuracy = this.windows.perfect.max;
-            }
-        }
-        this.result.bucket.index = this.bucket.index;
-        this.result.bucket.value = this.result.accuracy * 1000;
-        this.playHitEffects(time.now);
-        this.despawn = true;
+    playSlotLinears() {
+        // removed
     }
-    get useFallbackSprites() {
-        return (!this.sprites.left.exists ||
-            !this.sprites.middle.exists ||
-            !this.sprites.right.exists ||
-            !this.sprites.diamond.exists);
+    spawnSlotEffects() {
+        // removed
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.js
@@ -1,13 +1,13 @@
-import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.js';
-import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../buckets.js';
-import { effect } from '../../../../effect.js';
-import { lane } from '../../../../lane.js';
-import { particle } from '../../../../particle.js';
-import { skin } from '../../../../skin.js';
-import { archetypes } from '../../../index.js';
-import { SlideEndNote } from './SlideEndNote.js';
-export class CriticalSlideEndNote extends SlideEndNote {
+import { lane } from '../../../../../../../shared/src/engine/data/lane.js';
+import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.js';
+import { windows } from '../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../buckets.js';
+import { effect } from '../../../effect.js';
+import { particle } from '../../../particle.js';
+import { skin } from '../../../skin.js';
+import { archetypes } from '../../index.js';
+import { FlatNote } from './FlatNote.js';
+export class CriticalSlideEndNote extends FlatNote {
     sprites = {
         left: skin.sprites.criticalNoteLeft,
         middle: skin.sprites.criticalNoteMiddle,
@@ -22,6 +22,7 @@ export class CriticalSlideEndNote extends SlideEndNote {
         circularFallback: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalSlideLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectSlideTapYellow,
     };
     windows = windows.slideEndNote.critical;
     bucket = buckets.criticalSlideEndNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/CriticalSlideEndNote.js
@@ -1,13 +1,13 @@
-import { lane } from '../../../../../../../shared/src/engine/data/lane.js';
-import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.js';
-import { windows } from '../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../buckets.js';
-import { effect } from '../../../effect.js';
-import { particle } from '../../../particle.js';
-import { skin } from '../../../skin.js';
-import { archetypes } from '../../index.js';
-import { FlatNote } from './FlatNote.js';
-export class CriticalSlideEndNote extends FlatNote {
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.js';
+import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../buckets.js';
+import { effect } from '../../../../effect.js';
+import { lane } from '../../../../lane.js';
+import { particle } from '../../../../particle.js';
+import { skin } from '../../../../skin.js';
+import { archetypes } from '../../../index.js';
+import { SlideEndNote } from './SlideEndNote.js';
+export class CriticalSlideEndNote extends SlideEndNote {
     sprites = {
         left: skin.sprites.criticalNoteLeft,
         middle: skin.sprites.criticalNoteMiddle,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/NormalSlideEndNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/NormalSlideEndNote.js
@@ -1,11 +1,11 @@
-import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../buckets.js';
-import { effect } from '../../../../effect.js';
-import { particle } from '../../../../particle.js';
-import { skin } from '../../../../skin.js';
-import { archetypes } from '../../../index.js';
-import { SlideEndNote } from './SlideEndNote.js';
-export class NormalSlideEndNote extends SlideEndNote {
+import { windows } from '../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../buckets.js';
+import { effect } from '../../../effect.js';
+import { particle } from '../../../particle.js';
+import { skin } from '../../../skin.js';
+import { archetypes } from '../../index.js';
+import { FlatNote } from './FlatNote.js';
+export class NormalSlideEndNote extends FlatNote {
     sprites = {
         left: skin.sprites.slideNoteLeft,
         middle: skin.sprites.slideNoteMiddle,
@@ -18,6 +18,7 @@ export class NormalSlideEndNote extends SlideEndNote {
     effects = {
         circular: particle.effects.slideNoteCircular,
         linear: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectSlideTapGreen,
     };
     windows = windows.slideEndNote.normal;
     bucket = buckets.normalSlideEndNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/NormalSlideEndNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideEndNotes/NormalSlideEndNote.js
@@ -1,11 +1,11 @@
-import { windows } from '../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../buckets.js';
-import { effect } from '../../../effect.js';
-import { particle } from '../../../particle.js';
-import { skin } from '../../../skin.js';
-import { archetypes } from '../../index.js';
-import { FlatNote } from './FlatNote.js';
-export class NormalSlideEndNote extends FlatNote {
+import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../buckets.js';
+import { effect } from '../../../../effect.js';
+import { particle } from '../../../../particle.js';
+import { skin } from '../../../../skin.js';
+import { archetypes } from '../../../index.js';
+import { SlideEndNote } from './SlideEndNote.js';
+export class NormalSlideEndNote extends SlideEndNote {
     sprites = {
         left: skin.sprites.slideNoteLeft,
         middle: skin.sprites.slideNoteMiddle,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.js
@@ -1,8 +1,8 @@
+import { lane } from '../../../../../../../../shared/src/engine/data/lane.js';
 import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.js';
 import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
 import { buckets } from '../../../../buckets.js';
 import { effect } from '../../../../effect.js';
-import { lane } from '../../../../lane.js';
 import { particle } from '../../../../particle.js';
 import { skin } from '../../../../skin.js';
 import { archetypes } from '../../../index.js';
@@ -22,6 +22,7 @@ export class CriticalSlideStartNote extends SlideStartNote {
         circularFallback: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalSlideLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectSlideTapYellow,
     };
     windows = windows.slideStartNote.critical;
     bucket = buckets.criticalSlideStartNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.js
@@ -1,8 +1,8 @@
-import { lane } from '../../../../../../../../shared/src/engine/data/lane.js';
 import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.js';
 import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
 import { buckets } from '../../../../buckets.js';
 import { effect } from '../../../../effect.js';
+import { lane } from '../../../../lane.js';
 import { particle } from '../../../../particle.js';
 import { skin } from '../../../../skin.js';
 import { archetypes } from '../../../index.js';

--- a/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.js
@@ -18,6 +18,7 @@ export class NormalSlideStartNote extends SlideStartNote {
     effects = {
         circular: particle.effects.slideNoteCircular,
         linear: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectSlideTapGreen,
     };
     windows = windows.slideStartNote.normal;
     bucket = buckets.normalSlideStartNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.js
@@ -1,13 +1,13 @@
-import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.js';
-import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../buckets.js';
-import { effect } from '../../../../effect.js';
-import { lane } from '../../../../lane.js';
-import { particle } from '../../../../particle.js';
-import { skin } from '../../../../skin.js';
-import { archetypes } from '../../../index.js';
-import { TapNote } from './TapNote.js';
-export class CriticalTapNote extends TapNote {
+import { lane } from '../../../../../../../shared/src/engine/data/lane.js';
+import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.js';
+import { windows } from '../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../buckets.js';
+import { effect } from '../../../effect.js';
+import { particle } from '../../../particle.js';
+import { skin } from '../../../skin.js';
+import { archetypes } from '../../index.js';
+import { FlatNote } from './FlatNote.js';
+export class CriticalTapNote extends FlatNote {
     sprites = {
         left: skin.sprites.criticalNoteLeft,
         middle: skin.sprites.criticalNoteMiddle,
@@ -21,6 +21,7 @@ export class CriticalTapNote extends TapNote {
     effects = {
         circular: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectYellow,
     };
     windows = windows.tapNote.critical;
     bucket = buckets.criticalTapNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/CriticalTapNote.js
@@ -1,13 +1,13 @@
-import { lane } from '../../../../../../../shared/src/engine/data/lane.js';
-import { perspectiveLayout } from '../../../../../../../shared/src/engine/data/utils.js';
-import { windows } from '../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../buckets.js';
-import { effect } from '../../../effect.js';
-import { particle } from '../../../particle.js';
-import { skin } from '../../../skin.js';
-import { archetypes } from '../../index.js';
-import { FlatNote } from './FlatNote.js';
-export class CriticalTapNote extends FlatNote {
+import { perspectiveLayout } from '../../../../../../../../shared/src/engine/data/utils.js';
+import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../buckets.js';
+import { effect } from '../../../../effect.js';
+import { lane } from '../../../../lane.js';
+import { particle } from '../../../../particle.js';
+import { skin } from '../../../../skin.js';
+import { archetypes } from '../../../index.js';
+import { TapNote } from './TapNote.js';
+export class CriticalTapNote extends TapNote {
     sprites = {
         left: skin.sprites.criticalNoteLeft,
         middle: skin.sprites.criticalNoteMiddle,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/NormalTapNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/NormalTapNote.js
@@ -1,11 +1,11 @@
-import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../../buckets.js';
-import { effect } from '../../../../effect.js';
-import { particle } from '../../../../particle.js';
-import { skin } from '../../../../skin.js';
-import { archetypes } from '../../../index.js';
-import { TapNote } from './TapNote.js';
-export class NormalTapNote extends TapNote {
+import { windows } from '../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../buckets.js';
+import { effect } from '../../../effect.js';
+import { particle } from '../../../particle.js';
+import { skin } from '../../../skin.js';
+import { archetypes } from '../../index.js';
+import { FlatNote } from './FlatNote.js';
+export class NormalTapNote extends FlatNote {
     sprites = {
         left: skin.sprites.normalNoteLeft,
         middle: skin.sprites.normalNoteMiddle,
@@ -20,6 +20,7 @@ export class NormalTapNote extends TapNote {
     effects = {
         circular: particle.effects.normalNoteCircular,
         linear: particle.effects.normalNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.tapNote.normal;
     bucket = buckets.normalTapNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/NormalTapNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/tapNotes/NormalTapNote.js
@@ -1,11 +1,11 @@
-import { windows } from '../../../../../../../shared/src/engine/data/windows.js';
-import { buckets } from '../../../buckets.js';
-import { effect } from '../../../effect.js';
-import { particle } from '../../../particle.js';
-import { skin } from '../../../skin.js';
-import { archetypes } from '../../index.js';
-import { FlatNote } from './FlatNote.js';
-export class NormalTapNote extends FlatNote {
+import { windows } from '../../../../../../../../shared/src/engine/data/windows.js';
+import { buckets } from '../../../../buckets.js';
+import { effect } from '../../../../effect.js';
+import { particle } from '../../../../particle.js';
+import { skin } from '../../../../skin.js';
+import { archetypes } from '../../../index.js';
+import { TapNote } from './TapNote.js';
+export class NormalTapNote extends TapNote {
     sprites = {
         left: skin.sprites.normalNoteLeft,
         middle: skin.sprites.normalNoteMiddle,

--- a/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/CriticalSlideEndTraceNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/CriticalSlideEndTraceNote.js
@@ -22,6 +22,7 @@ export class CriticalSlideEndTraceNote extends TraceNote {
         circularFallback: particle.effects.criticalSlideTickNote,
         linear: particle.effects.criticalTraceNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.slideEndTraceNote.critical;
     bucket = buckets.criticalSlideEndTraceNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/CriticalSlideTraceNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/CriticalSlideTraceNote.js
@@ -22,6 +22,7 @@ export class CriticalSlideTraceNote extends TraceNote {
         circularFallback: particle.effects.criticalSlideTickNote,
         linear: particle.effects.criticalTraceNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.slideTraceNote.critical;
     bucket = buckets.criticalSlideTraceNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/CriticalTraceNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/CriticalTraceNote.js
@@ -32,7 +32,4 @@ export class CriticalTraceNote extends TraceNote {
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect;
     }
-    playLaneEffects() {
-        //
-    }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/CriticalTraceNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/CriticalTraceNote.js
@@ -22,6 +22,7 @@ export class CriticalTraceNote extends TraceNote {
         circularFallback: particle.effects.criticalSlideTickNote,
         linear: particle.effects.criticalTraceNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectYellow,
     };
     windows = windows.traceNote.critical;
     bucket = buckets.criticalTraceNote;
@@ -30,5 +31,8 @@ export class CriticalTraceNote extends TraceNote {
     }
     get slotGlowEffect() {
         return archetypes.CriticalSlotGlowEffect;
+    }
+    playLaneEffects() {
+        //
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/NormalSlideEndTraceNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/NormalSlideEndTraceNote.js
@@ -22,6 +22,7 @@ export class NormalSlideEndTraceNote extends TraceNote {
         circularFallback: particle.effects.normalSlideTickNote,
         linear: particle.effects.normalTraceNoteLinear,
         linearFallback: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.slideEndTraceNote.normal;
     bucket = buckets.normalSlideEndTraceNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/NormalSlideTraceNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/NormalSlideTraceNote.js
@@ -22,6 +22,7 @@ export class NormalSlideTraceNote extends TraceNote {
         circularFallback: particle.effects.normalSlideTickNote,
         linear: particle.effects.normalTraceNoteLinear,
         linearFallback: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.slideTraceNote.normal;
     bucket = buckets.normalSlideTraceNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/NormalTraceNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/NormalTraceNote.js
@@ -22,6 +22,7 @@ export class NormalTraceNote extends TraceNote {
         circularFallback: particle.effects.normalSlideTickNote,
         linear: particle.effects.normalTraceNoteLinear,
         linearFallback: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.traceNote.normal;
     bucket = buckets.normalTraceNote;

--- a/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/TraceNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/TraceNote.js
@@ -2,19 +2,22 @@ import { note } from '../../../../note.js';
 import { flatEffectLayout, particle } from '../../../../particle.js';
 import { scaledScreen } from '../../../../scaledScreen.js';
 import { getZ, layer } from '../../../../skin.js';
+import { disallowEmpty } from '../../../InputManager.js';
 import { FlatNote } from '../FlatNote.js';
 export class TraceNote extends FlatNote {
+    leniency = 1;
     layer = layer.note.trace;
+    earlyInputTime = this.entityMemory(Number);
+    earlyHitTime = this.entityMemory(Number);
     diamondLayout = this.entityMemory(Rect);
     diamondZ = this.entityMemory(Number);
-    get useFallbackSprites() {
-        return (!this.sprites.left.exists ||
-            !this.sprites.middle.exists ||
-            !this.sprites.right.exists ||
-            !this.sprites.diamond.exists);
-    }
-    globalInitialize() {
-        super.globalInitialize();
+    judExport = this.defineExport({
+        jud: { name: 'jud', type: Number },
+    });
+    initialize() {
+        super.initialize();
+        this.earlyInputTime = this.targetTime + input.offset;
+        this.earlyHitTime = -9999;
         if (!this.useFallbackSprites) {
             const w = note.h / scaledScreen.wToH;
             new Rect({
@@ -26,19 +29,82 @@ export class TraceNote extends FlatNote {
             this.diamondZ = getZ(layer.note.tick, this.targetTime, this.import.lane);
         }
     }
+    touch() {
+        if (time.now < this.inputTime.min)
+            return;
+        if (time.now < this.earlyInputTime) {
+            this.earlyTouch();
+        }
+        else {
+            this.lateTouch();
+        }
+    }
+    updateParallel() {
+        this.triggerEarlyTouch();
+        super.updateParallel();
+    }
+    earlyTouch() {
+        for (const touch of touches) {
+            if (!this.fullHitbox.contains(touch.position))
+                continue;
+            disallowEmpty(touch);
+            this.earlyHitTime = touch.time;
+            return;
+        }
+    }
+    lateTouch() {
+        for (const touch of touches) {
+            if (!this.fullHitbox.contains(touch.position))
+                continue;
+            disallowEmpty(touch);
+            this.complete(Math.max(touch.time, this.targetTime));
+            return;
+        }
+    }
+    triggerEarlyTouch() {
+        if (this.despawn)
+            return;
+        if (time.now < this.earlyInputTime)
+            return;
+        if (this.earlyHitTime === -9999)
+            return;
+        this.complete(this.earlyHitTime);
+        this.despawn = true;
+    }
     render() {
         super.render();
         if (!this.useFallbackSprites) {
             this.sprites.diamond.draw(this.diamondLayout.mul(this.y), this.diamondZ, 1);
         }
     }
+    complete(hitTime) {
+        this.result.judgment = input.judge(hitTime, this.targetTime, this.windows);
+        this.result.accuracy = hitTime - this.targetTime;
+        this.result.bucket.index = this.bucket.index;
+        this.result.bucket.value = this.result.accuracy * 1000;
+        this.playHitEffects(time.now);
+        this.despawn = true;
+        if (this.windows.perfect.min > this.result.accuracy)
+            this.judExport('jud', 1);
+        else if (this.windows.perfect.max < this.result.accuracy)
+            this.judExport('jud', 2);
+    }
     playCircularNoteEffect() {
         particle.effects.spawn(this.circularEffectId, flatEffectLayout({ lane: this.import.lane }), 0.6, false);
     }
-    playSlotLinears() {
+    playSlotEffects() {
         // removed
     }
-    spawnSlotEffects() {
+    playSlotLinears() {
+        //removed
+    }
+    playLaneEffects() {
         // removed
+    }
+    get useFallbackSprites() {
+        return (!this.sprites.left.exists ||
+            !this.sprites.middle.exists ||
+            !this.sprites.right.exists ||
+            !this.sprites.diamond.exists);
     }
 }

--- a/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/TraceNote.js
+++ b/play/src/engine/playData/archetypes/notes/flatNotes/traceNotes/TraceNote.js
@@ -2,22 +2,19 @@ import { note } from '../../../../note.js';
 import { flatEffectLayout, particle } from '../../../../particle.js';
 import { scaledScreen } from '../../../../scaledScreen.js';
 import { getZ, layer } from '../../../../skin.js';
-import { disallowEmpty } from '../../../InputManager.js';
 import { FlatNote } from '../FlatNote.js';
 export class TraceNote extends FlatNote {
-    leniency = 1;
     layer = layer.note.trace;
-    earlyInputTime = this.entityMemory(Number);
-    earlyHitTime = this.entityMemory(Number);
     diamondLayout = this.entityMemory(Rect);
     diamondZ = this.entityMemory(Number);
-    judExport = this.defineExport({
-        jud: { name: 'jud', type: Number },
-    });
-    initialize() {
-        super.initialize();
-        this.earlyInputTime = this.targetTime + input.offset;
-        this.earlyHitTime = -9999;
+    get useFallbackSprites() {
+        return (!this.sprites.left.exists ||
+            !this.sprites.middle.exists ||
+            !this.sprites.right.exists ||
+            !this.sprites.diamond.exists);
+    }
+    globalInitialize() {
+        super.globalInitialize();
         if (!this.useFallbackSprites) {
             const w = note.h / scaledScreen.wToH;
             new Rect({
@@ -29,79 +26,19 @@ export class TraceNote extends FlatNote {
             this.diamondZ = getZ(layer.note.tick, this.targetTime, this.import.lane);
         }
     }
-    touch() {
-        if (time.now < this.inputTime.min)
-            return;
-        if (time.now < this.earlyInputTime) {
-            this.earlyTouch();
-        }
-        else {
-            this.lateTouch();
-        }
-    }
-    updateParallel() {
-        this.triggerEarlyTouch();
-        super.updateParallel();
-    }
-    earlyTouch() {
-        for (const touch of touches) {
-            if (!this.fullHitbox.contains(touch.position))
-                continue;
-            disallowEmpty(touch);
-            this.earlyHitTime = touch.time;
-            return;
-        }
-    }
-    lateTouch() {
-        for (const touch of touches) {
-            if (!this.fullHitbox.contains(touch.position))
-                continue;
-            disallowEmpty(touch);
-            this.complete(Math.max(touch.time, this.targetTime));
-            return;
-        }
-    }
-    triggerEarlyTouch() {
-        if (this.despawn)
-            return;
-        if (time.now < this.earlyInputTime)
-            return;
-        if (this.earlyHitTime === -9999)
-            return;
-        this.complete(this.earlyHitTime);
-        this.despawn = true;
-    }
     render() {
         super.render();
         if (!this.useFallbackSprites) {
             this.sprites.diamond.draw(this.diamondLayout.mul(this.y), this.diamondZ, 1);
         }
     }
-    complete(hitTime) {
-        this.result.judgment = input.judge(hitTime, this.targetTime, this.windows);
-        this.result.accuracy = hitTime - this.targetTime;
-        this.result.bucket.index = this.bucket.index;
-        this.result.bucket.value = this.result.accuracy * 1000;
-        this.playHitEffects(time.now);
-        this.despawn = true;
-        if (this.windows.perfect.min > this.result.accuracy)
-            this.judExport('jud', 1);
-        else if (this.windows.perfect.max < this.result.accuracy)
-            this.judExport('jud', 2);
-    }
     playCircularNoteEffect() {
         particle.effects.spawn(this.circularEffectId, flatEffectLayout({ lane: this.import.lane }), 0.6, false);
     }
-    playSlotEffects() {
+    playSlotLinears() {
         // removed
     }
-    playLaneEffects() {
+    spawnSlotEffects() {
         // removed
-    }
-    get useFallbackSprites() {
-        return (!this.sprites.left.exists ||
-            !this.sprites.middle.exists ||
-            !this.sprites.right.exists ||
-            !this.sprites.diamond.exists);
     }
 }

--- a/play/src/engine/playData/particle.js
+++ b/play/src/engine/playData/particle.js
@@ -31,6 +31,12 @@ export const particle = defineParticle({
         normalSlideConnectorLinear: ParticleEffectName.NoteLinearHoldGreen,
         criticalSlideConnectorCircular: ParticleEffectName.NoteCircularHoldYellow,
         criticalSlideConnectorLinear: ParticleEffectName.NoteLinearHoldYellow,
+        slotEffectCyan: 'Sekai Slot Linear Tap Cyan',
+        slotEffectYellow: 'Sekai Slot Linear Tap Yellow',
+        slotEffectSlideTapGreen: 'Sekai Slot Linear Slide Tap Green',
+        slotEffectSlideTapYellow: 'Sekai Slot Linear Slide Tap Yellow',
+        slotEffectFlickRed: 'Sekai Slot Linear Alternative Red',
+        slotEffectFlickYellow: 'Sekai Slot Linear Alternative Yellow',
     },
 });
 export const circularEffectLayout = ({ lane, w, h }) => {

--- a/shared/src/engine/configuration/options.js
+++ b/shared/src/engine/configuration/options.js
@@ -166,6 +166,12 @@ export const optionsDefinition = {
         type: 'toggle',
         def: 1,
     },
+    slotLinearEnabled: {
+        name: 'Enable Fancy Slot Effects',
+        scope: 'Sekai',
+        type: 'toggle',
+        def: 1,
+    },
     slotEffectSize: {
         name: Text.SlotEffectSize,
         scope: 'Sekai',

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalSlideEndNote.js
@@ -22,6 +22,7 @@ export class CriticalSlideEndNote extends FlatNote {
         circularFallback: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalSlideLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectSlideTapYellow,
     };
     windows = windows.slideEndNote.critical;
     bucket = buckets.criticalSlideEndNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalTapNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/CriticalTapNote.js
@@ -21,6 +21,7 @@ export class CriticalTapNote extends FlatNote {
     effects = {
         circular: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectYellow,
     };
     windows = windows.tapNote.critical;
     bucket = buckets.criticalTapNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/FlatNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/FlatNote.js
@@ -90,6 +90,9 @@ export class FlatNote extends Note {
             ? this.effects.linearFallback.id
             : this.effects.linear.id;
     }
+    get slotEffectId() {
+        return this.effects.slotEffects.id
+    }
     get hitTime() {
         return this.targetTime + (replay.isReplay ? this.import.accuracy : 0);
     }
@@ -161,6 +164,8 @@ export class FlatNote extends Note {
             this.playNoteEffects();
         if (options.laneEffectEnabled)
             this.playLaneEffects();
+        if (options.slotLinearEnabled)
+            this.playSlotLinears();
     }
     playNoteEffects() {
         this.playLinearNoteEffect();
@@ -195,6 +200,24 @@ export class FlatNote extends Note {
                 b: lane.b,
                 t: lane.t,
             }), 0.3, false);
+        }
+    }
+    playSlotLinears() {
+        if (this.effects.slotEffects.exists) {
+            const start = Math.floor(this.import.lane - this.import.size)
+            const end = Math.ceil(this.import.lane + this.import.size)
+
+            for (let i = start; i < end; i++) {
+                particle.effects.spawn(
+                    this.slotEffectId,
+                    linearEffectLayout({
+                        lane: i + 0.5,
+                        shear: 0,
+                    }),
+                    0.5,
+                    false,
+                )
+            }
         }
     }
     spawnSlotEffects(startTime) {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/NormalSlideEndNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/NormalSlideEndNote.js
@@ -18,6 +18,7 @@ export class NormalSlideEndNote extends FlatNote {
     effects = {
         circular: particle.effects.slideNoteCircular,
         linear: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectSlideTapGreen,
     };
     windows = windows.slideEndNote.normal;
     bucket = buckets.normalSlideEndNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/NormalTapNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/NormalTapNote.js
@@ -20,6 +20,7 @@ export class NormalTapNote extends FlatNote {
     effects = {
         circular: particle.effects.normalNoteCircular,
         linear: particle.effects.normalNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.tapNote.normal;
     bucket = buckets.normalTapNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalFlickNote.js
@@ -23,6 +23,7 @@ export class CriticalFlickNote extends FlickNote {
         circularFallback: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalFlickNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectFlickYellow,
     };
     arrowSprites = {
         up: [

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/CriticalSlideEndFlickNote.js
@@ -26,6 +26,7 @@ export class CriticalSlideEndFlickNote extends FlickNote {
         circularFallback: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalFlickNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectFlickYellow,
     };
     arrowSprites = {
         up: [

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/NormalFlickNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/NormalFlickNote.js
@@ -20,6 +20,7 @@ export class NormalFlickNote extends FlickNote {
     effects = {
         circular: particle.effects.flickNoteCircular,
         linear: particle.effects.flickNoteLinear,
+        slotEffects: particle.effects.slotEffectFlickRed,
     };
     arrowSprites = {
         up: [

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/NormalSlideEndFlickNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/NormalSlideEndFlickNote.js
@@ -20,6 +20,7 @@ export class NormalSlideEndFlickNote extends FlickNote {
     effects = {
         circular: particle.effects.flickNoteCircular,
         linear: particle.effects.flickNoteLinear,
+        slotEffects: particle.effects.slotEffectFlickRed,
     };
     arrowSprites = {
         up: [

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/CriticalTraceFlickNote.js
@@ -24,6 +24,7 @@ export class CriticalTraceFlickNote extends TraceFlickNote {
     effects = {
         circular: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     arrowSprites = {
         up: [

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/NormalTraceFlickNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/NormalTraceFlickNote.js
@@ -21,6 +21,7 @@ export class NormalTraceFlickNote extends TraceFlickNote {
     effects = {
         circular: particle.effects.flickNoteCircular,
         linear: particle.effects.flickNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     arrowSprites = {
         up: [

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/TraceFlickNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/flickNotes/traceFlickNotes/TraceFlickNote.js
@@ -36,6 +36,9 @@ export class TraceFlickNote extends FlickNote {
     playLaneEffects() {
         // removed
     }
+    playSlotLinears() {
+        // removed
+    }
     spawnSlotEffects() {
         // removed
     }

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/CriticalSlideStartNote.js
@@ -22,6 +22,7 @@ export class CriticalSlideStartNote extends SlideStartNote {
         circularFallback: particle.effects.criticalNoteCircular,
         linear: particle.effects.criticalSlideLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectSlideTapYellow,
     };
     windows = windows.slideStartNote.critical;
     bucket = buckets.criticalSlideStartNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/slideStartNotes/NormalSlideStartNote.js
@@ -18,6 +18,7 @@ export class NormalSlideStartNote extends SlideStartNote {
     effects = {
         circular: particle.effects.slideNoteCircular,
         linear: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectSlideTapGreen,
     };
     windows = windows.slideStartNote.normal;
     bucket = buckets.normalSlideStartNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/CriticalSlideEndTraceNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/CriticalSlideEndTraceNote.js
@@ -22,6 +22,7 @@ export class CriticalSlideEndTraceNote extends TraceNote {
         circularFallback: particle.effects.criticalSlideTickNote,
         linear: particle.effects.criticalTraceNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.slideEndTraceNote.critical;
     bucket = buckets.criticalSlideEndTraceNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/CriticalSlideTraceNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/CriticalSlideTraceNote.js
@@ -22,6 +22,7 @@ export class CriticalSlideTraceNote extends TraceNote {
         circularFallback: particle.effects.criticalSlideTickNote,
         linear: particle.effects.criticalTraceNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.slideTraceNote.critical;
     bucket = buckets.criticalSlideTraceNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/CriticalTraceNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/CriticalTraceNote.js
@@ -22,6 +22,7 @@ export class CriticalTraceNote extends TraceNote {
         circularFallback: particle.effects.criticalSlideTickNote,
         linear: particle.effects.criticalTraceNoteLinear,
         linearFallback: particle.effects.criticalNoteLinear,
+        slotEffects: particle.effects.slotEffectYellow,
     };
     windows = windows.traceNote.critical;
     bucket = buckets.criticalTraceNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/NormalSlideEndTraceNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/NormalSlideEndTraceNote.js
@@ -22,6 +22,7 @@ export class NormalSlideEndTraceNote extends TraceNote {
         circularFallback: particle.effects.normalSlideTickNote,
         linear: particle.effects.normalTraceNoteLinear,
         linearFallback: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.slideEndTraceNote.normal;
     bucket = buckets.normalSlideEndTraceNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/NormalSlideTraceNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/NormalSlideTraceNote.js
@@ -22,6 +22,7 @@ export class NormalSlideTraceNote extends TraceNote {
         circularFallback: particle.effects.normalSlideTickNote,
         linear: particle.effects.normalTraceNoteLinear,
         linearFallback: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.slideTraceNote.normal;
     bucket = buckets.normalSlideTraceNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/NormalTraceNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/NormalTraceNote.js
@@ -22,6 +22,7 @@ export class NormalTraceNote extends TraceNote {
         circularFallback: particle.effects.normalSlideTickNote,
         linear: particle.effects.normalTraceNoteLinear,
         linearFallback: particle.effects.slideNoteLinear,
+        slotEffects: particle.effects.slotEffectCyan,
     };
     windows = windows.traceNote.normal;
     bucket = buckets.normalTraceNote;

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/TraceNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/TraceNote.js
@@ -35,7 +35,7 @@ export class TraceNote extends FlatNote {
     playCircularNoteEffect() {
         particle.effects.spawn(this.circularEffectId, flatEffectLayout({ lane: this.import.lane }), 0.6, false);
     }
-    playLaneEffects() {
+    playSlotLinears() {
         // removed
     }
     spawnSlotEffects() {

--- a/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/TraceNote.js
+++ b/watch/src/engine/watchData/archetypes/notes/flatNotes/traceNotes/TraceNote.js
@@ -35,6 +35,9 @@ export class TraceNote extends FlatNote {
     playCircularNoteEffect() {
         particle.effects.spawn(this.circularEffectId, flatEffectLayout({ lane: this.import.lane }), 0.6, false);
     }
+    playLaneEffects() {
+        // removed
+    }
     playSlotLinears() {
         // removed
     }

--- a/watch/src/engine/watchData/particle.js
+++ b/watch/src/engine/watchData/particle.js
@@ -31,6 +31,12 @@ export const particle = defineParticle({
         normalSlideConnectorLinear: ParticleEffectName.NoteLinearHoldGreen,
         criticalSlideConnectorCircular: ParticleEffectName.NoteCircularHoldYellow,
         criticalSlideConnectorLinear: ParticleEffectName.NoteLinearHoldYellow,
+        slotEffectCyan: 'Sekai Slot Linear Tap Cyan',
+        slotEffectYellow: 'Sekai Slot Linear Tap Yellow',
+        slotEffectSlideTapGreen: 'Sekai Slot Linear Slide Tap Green',
+        slotEffectSlideTapYellow: 'Sekai Slot Linear Slide Tap Yellow',
+        slotEffectFlickRed: 'Sekai Slot Linear Alternative Red',
+        slotEffectFlickYellow: 'Sekai Slot Linear Alternative Yellow',
     },
 });
 export const circularEffectLayout = ({ lane, w, h }) => {


### PR DESCRIPTION
Adds slot effects alongside the linear and circular particle effects, which does linear particles but triggers on every lane a note covers.

Custom particle name additions:
- Sekai Slot Linear Tap Cyan
- Sekai Slot Linear Tap Yellow
- Sekai Slot Linear Slide Tap Green
- Sekai Slot Linear Slide Tap Yellow
- Sekai Slot Linear Alternative Red
- Sekai Slot Linear Alternative Yellow